### PR TITLE
Add management Multus network and attach to Home Assistant

### DIFF
--- a/kubernetes/apps/automation/homeassistant/app/deployment.yaml
+++ b/kubernetes/apps/automation/homeassistant/app/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         k8s.v1.cni.cncf.io/networks: |
           [
             {"name": "multus-iot", "namespace": "network", "ips": ["192.168.20.9/24"]},
+            {"name": "multus-mgmt", "namespace": "network", "ips": ["192.168.254.9/24"]},
             {"name": "multus-not", "namespace": "network", "ips": ["192.168.30.9/24"]}
           ]
     spec:

--- a/kubernetes/apps/network/multus/config/kustomization.yaml
+++ b/kubernetes/apps/network/multus/config/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./net-attach-iot.yaml
+  - ./net-attach-mgmt.yaml
   - ./net-attach-not.yaml
   - ./net-attach-trusted.yaml

--- a/kubernetes/apps/network/multus/config/net-attach-mgmt.yaml
+++ b/kubernetes/apps/network/multus/config/net-attach-mgmt.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: multus-mgmt
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "multus-mgmt",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "eth0",
+          "mode": "bridge",
+          "capabilities": {
+            "ips": true
+          },
+          "ipam": {
+            "type": "static"
+          }
+        }
+      ]
+    }


### PR DESCRIPTION
## Summary

- Add management network (192.168.254.0/24) Multus NAD (`multus-mgmt`) on `eth0` (untagged)
- Attach management network to Home Assistant pod with IP `192.168.254.9/24`

## Test plan

- [ ] Verify HA pod gets `192.168.254.9` on mgmt interface and can reach the NAS
- [ ] Confirm HA's existing IoT/NoT Multus interfaces still work after adding mgmt

https://claude.ai/code/session_01HYVX1DHFbBR2LEMuBrrn7X