### PR TITLE
fix(frigate): replace deprecated record.retain config

### DIFF
--- a/kubernetes/apps/automation/frigate/app/config/config.yml
+++ b/kubernetes/apps/automation/frigate/app/config/config.yml
@@ -97,9 +97,10 @@ objects:
 
 record:
   enabled: true
-  retain:
+  continuous:
     days: 7
-    mode: all
+  motion:
+    days: 7
   detections:
     retain:
       days: 10


### PR DESCRIPTION
## Summary
- Frigate 0.17.0 removed the top-level `record.retain` key, causing: `record -> retain - Extra inputs are not permitted`
- Replaced with `record.continuous` and `record.motion` sections per the new schema
- Retention stays at 7 days for both, matching the previous `retain.days: 7, mode: all`

## Test plan
- [ ] Verify Frigate pod starts without config validation errors
- [ ] Confirm recordings are being retained as expected

https://claude.ai/code/session_014cZHwPSdwKWC39erejuNn1