### PR TITLE
feat(frigate): add Prometheus monitoring and alerting

### DIFF
--- a/kubernetes/apps/automation/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/automation/frigate/app/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: automation
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./podmonitor.yaml
+  - ./prometheusrule.yaml
   - ./route.yaml
   - ../../../../templates/volsync
 configMapGenerator:

--- a/kubernetes/apps/automation/frigate/app/podmonitor.yaml
+++ b/kubernetes/apps/automation/frigate/app/podmonitor.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: frigate
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frigate
+  podMetricsEndpoints:
+    - port: http
+      path: /api/metrics
+      interval: 60s

--- a/kubernetes/apps/automation/frigate/app/prometheusrule.yaml
+++ b/kubernetes/apps/automation/frigate/app/prometheusrule.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: frigate
+spec:
+  groups:
+    - name: frigate
+      rules:
+        - alert: FrigateDown
+          expr: absent(frigate_service_uptime_seconds) == 1
+          for: 50m
+          labels:
+            severity: critical
+          annotations:
+            summary: Frigate is unreachable
+            description: frigate_service_uptime_seconds has been absent for more than 50 minutes.
+        - alert: FrigateDown
+          expr: deriv(frigate_service_uptime_seconds[15m]) == 0
+          for: 50m
+          labels:
+            severity: critical
+          annotations:
+            summary: Frigate uptime is not increasing
+            description: frigate_service_uptime_seconds has not increased for more than 50 minutes — Frigate may be hung.
+        - alert: FrigateCameraMissing
+          expr: absent(frigate_camera_fps{camera_name="doorbell"}) == 1
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: Frigate camera missing — doorbell
+            description: No metrics received from doorbell camera for more than 1 hour. Frigate may be in safe mode.
+        - alert: FrigateCameraMissing
+          expr: absent(frigate_camera_fps{camera_name="driveway_wide"}) == 1
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: Frigate camera missing — driveway_wide
+            description: No metrics received from driveway_wide camera for more than 1 hour. Frigate may be in safe mode.
+        - alert: FrigateCameraMissing
+          expr: absent(frigate_camera_fps{camera_name="bay_window_wide"}) == 1
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: Frigate camera missing — bay_window_wide
+            description: No metrics received from bay_window_wide camera for more than 1 hour. Frigate may be in safe mode.
+        - alert: FrigateCameraMissing
+          expr: absent(frigate_camera_fps{camera_name="mountain_side_wide"}) == 1
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: Frigate camera missing — mountain_side_wide
+            description: No metrics received from mountain_side_wide camera for more than 1 hour. Frigate may be in safe mode.

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanager.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanager.yaml
@@ -32,6 +32,15 @@ spec:
         - name: severity
           value: warning
           matchType: =
+    - equal: ["namespace"]
+      sourceMatch:
+        - name: alertname
+          value: FrigateDown
+          matchType: =
+      targetMatch:
+        - name: alertname
+          value: FrigateCameraMissing
+          matchType: =
   receivers:
     - name: "null"
     - name: pushover


### PR DESCRIPTION
## Summary
- Add PodMonitor to scrape Frigate's `/api/metrics` endpoint for Prometheus
- Add PrometheusRules to alert when:
  - **FrigateDown** (50m): `frigate_service_uptime_seconds` is absent or not increasing — catches Frigate being unreachable or hung
  - **FrigateCameraMissing** (1h): `frigate_camera_fps` absent for any main camera (doorbell, driveway_wide, bay_window_wide, mountain_side_wide) — catches safe mode and camera disconnections
- Add Alertmanager inhibit rule so FrigateDown suppresses FrigateCameraMissing (1 alert instead of 5 when Frigate is hard down)
- FrigateDown fires at 50m, FrigateCameraMissing at 1h, giving 10m for the inhibit to take effect

## Test plan
- [ ] Verify PodMonitor appears: `kubectl get podmonitor -n automation`
- [ ] Verify PrometheusRule appears: `kubectl get prometheusrule -n automation`
- [ ] Check Prometheus targets UI for Frigate scrape target
- [ ] Check Prometheus alerts UI for FrigateDown and FrigateCameraMissing rules
- [ ] Confirm alerts route to Pushover via existing Alertmanager config

https://claude.ai/code/session_014cZHwPSdwKWC39erejuNn1